### PR TITLE
fix: options type handling in OnPlayEnd

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -201,6 +201,9 @@ function OnPlayEnd(source, id, soundId, data, options)
     if nextSound then
         local netId = Surround:getSoundNetId(soundId)
         TriggerClientEvent('mx-audioplayer:setWaitingForResponse', -1, id, true)
+        if type(options) ~= "table" then
+            options = {}
+        end
         options.silent = false
         playSound(source, id, {
             soundId = nextSound.soundId .. id,


### PR DESCRIPTION
fix #186 
seems like it returns string sometimes which crashes the script, this fix ensured for me that it wouldn't crash, since it converts to table first